### PR TITLE
Add static analysis

### DIFF
--- a/.github/workflows/build_static_analysis.yml
+++ b/.github/workflows/build_static_analysis.yml
@@ -169,6 +169,23 @@ jobs:
         cppcheck --errorlist > errorlist.xml
         cd build ; cmake --build . --target cppcheck
 
+    - name: Fix SARIF file
+      run: |
+          python3 -c "
+          import json
+          with open('cppcheck_report.sarif', 'r') as f:
+              data = json.load(f)
+          for run in data.get('runs', []):
+              for result in run.get('results', []):
+                  for location in result.get('locations', []):
+                      region = location.get('physicalLocation', {}).get('region', {})
+                      for key in ['startColumn', 'endColumn', 'startLine', 'endLine']:
+                          if region.get(key, 1) == 0:
+                              region[key] = 1
+          with open('cppcheck_report.sarif', 'w') as f:
+              json.dump(data, f, indent=2)
+          "
+
     - name: Upload CPPCheck report
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build_static_analysis.yml
+++ b/.github/workflows/build_static_analysis.yml
@@ -1,0 +1,237 @@
+name: Build and Static Analysis
+
+run-name: BandS "#${{github.run_number}}" [ ${{github.run_attempt}} ] [ ${{github.event.head_commit.message}} ] 
+
+on:
+  push:
+    branches-ignore: "main"
+
+  pull_request:
+    branches: [ "master", "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    container:
+      image: sjaekim/kuase_dev:v0.8
+
+    env:
+        BUILD_TYPE: Release
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Boost
+      run: |
+        apt-get update
+        apt-get install -y libboost-all-dev
+
+    - name: Configure Submodules
+      run: |
+        git config --global --add safe.directory '*'
+        git submodule update --init --recursive
+    
+    - name: Configure CMake Environment
+      run: cmake -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build the project
+      run: cmake --build $GITHUB_WORKSPACE/build --config ${{env.BUILD_TYPE}}
+            
+    - name: Upload build directory
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-dir
+        path: build/
+        if-no-files-found: error
+
+  GoogleTest:  
+    needs: build
+    runs-on: self-hosted
+    container:
+      image: sjaekim/kuase_dev:v0.8
+
+    env:
+        BUILD_TYPE: Release
+
+    steps:  
+    - name: Download build directory
+      uses: actions/download-artifact@v4
+      with:
+        name: build-dir
+        path: build/
+    
+    - name: Install Boost
+      run: |
+        apt-get update
+        apt-get install -y libboost-all-dev
+
+    - name: Prepare GoogleTest
+      run: |
+        cd build
+        cmake -DBUILD_TESTS=ON ..
+        cmake --build . --target googletest
+    - name: Run GoogleTest
+      run: |
+        cd build
+        ctest --output-on-failure --verbose
+
+  GCovr:  
+    needs: GoogleTest
+    runs-on: self-hosted
+    container:
+      image: sjaekim/kuase_dev:v0.8
+
+    env:
+        BUILD_TYPE: Release
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Boost
+      run: |
+        apt-get update
+        apt-get install -y libboost-all-dev
+
+    - name: Prepare GCovr
+      run: |
+        git config --global --add safe.directory '*'
+        mkdir -p build
+        cd build
+        cmake .. -DENABLE_COVERAGE=ON -DBUILD_TESTS=ON
+        cmake --build . --target googletest
+
+    - name: Run GoogleTest
+      run: |
+        cd build
+        ctest --output-on-failure --verbose
+
+    - name: Run GCovr
+      run: |
+        git config --global --add safe.directory '*'
+        cd build
+        cmake --build . --target coverage
+
+    - name: Upload Test GCovr report
+      uses: actions/upload-artifact@v4
+      with:
+        name: Gcovr Html
+        path: build/coverage/
+        if-no-files-found: error
+
+    - name: Upload Test GCovr Coverall Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: Gcovr Coverall
+        path: build/coverage.json
+        if-no-files-found: error
+
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        file: build/coverage.json
+
+  CPPCheck:  
+    runs-on: self-hosted
+    container:
+      image: sjaekim/kuase_dev:v0.8
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    env:
+        BUILD_TYPE: Release
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Boost
+      run: |
+        apt-get update
+        apt-get install -y libboost-all-dev
+
+    - name: Prepare CPPCheck
+      run: |
+        git config --global --add safe.directory '*'
+        mkdir -p build
+        cd build
+        cmake ..
+
+    - name: Run CPPCheck
+      run: |
+        cppcheck --errorlist > errorlist.xml
+        cd build ; cmake --build . --target cppcheck
+
+    - name: Upload CPPCheck report
+      uses: actions/upload-artifact@v4
+      with:
+        name: cppcheck_report
+        path: cppcheck_report.sarif
+    
+    - name: Upload SARIF report to Github
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: cppcheck_report.sarif
+        category: cppcheck
+      continue-on-error: true  # 이 옵션 추가
+
+  # SonarCloud:
+  #   needs: [GoogleTest, GCovr]
+  #   runs-on: self-hosted
+  #   container:
+  #     image: sjaekim/kuase_dev:v0.8
+
+  #   env:
+  #       BUILD_TYPE: Release
+  #       BUILD_WRAPPER_OUT_DIR: build
+
+  #   steps:
+  #   - name: Checkout Repository
+  #     uses: actions/checkout@v4
+
+  #   - name: Download GCovr html report
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: Gcovr Html
+  #       path: coverage/
+  #       if-no-files-found: error
+
+  #   - name: Prepare SonarCloud
+  #     run: |
+  #       git config --global --add safe.directory '*'
+  #       mkdir -p build
+  #       cd build
+  #       cmake .. -DENABLE_COVERAGE=ON -DBUILD_TESTS=ON
+  #       cmake --build . --target googletest
+  #       cmake --build .
+
+  #   - name: Install Build Wrapper
+  #     uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5
+
+  #   - name: Run Build Wrapper
+  #     run: |
+  #       build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/
+
+  #   - name: SonarQube Scan
+  #     uses: SonarSource/sonarqube-scan-action@v5
+  #     env:
+  #       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #     with:
+  #       args: >
+  #         --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
+
+  #   # - name: Run SonarCloud Analysis
+  #   #   run: |
+  #   #     sonar-scanner \
+  #   #       -Dsonar.sources=src \
+  #   #       -Dsonar.tests=tests \
+  #   #       -Dsonar.cxx.gcov.reportPath=coverage/coverage.html \
+  #   #       -Dsonar.host.url=https://sonarcloud.io \
+  #   #       -Dsonar.login=${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Static Analysis 에 대한 업데이트입니다.

Github Action에 Build and Static Analysis 가 추가되었습니다.

각 Static Analysis 의 결과는 다음과 같이 확인 가능합니다.

1. CPPCheck 확인 위치
SMA_T5 Gihub -> Security -> Code Scanning -> is:open branch:main에서 branch를 변경하면 다른 브랜치에서 수행된 cppcheck의 결과를 확인할 수 있음.

2. Coverage 확인 사이트 (Gcovr 결과)
https://coveralls.io/github/KUASE-V3/SMA_T6

3. SonarCloud
https://sonarcloud.io/project/overview?id=KUASE-V3_SMA_T6

위의 사이트에서 확인 가능하며 cppcheck에 한해서

```bash
cd build
cmake ..
cmake --build . --target cppcheck
```

를 수행하시면, cppcheck의 결과를 개발 컴퓨팅 환경에서도 확인 가능합니다.

